### PR TITLE
Skip compilation or unit tests in arduino_ci_remote.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `ArduinoInstallation` and `ArduinoDownloader` now allow console output to optionally be set to an `IO` object of choice during `force_install`
 - `ArduinoInstallation::force_install` now optionally accepts a version string
 - `arduino_library_location.rb` script to print Arduino library location to stdout
+- `arduino_ci_remote.rb` now supports `--skip-unittests` and `--skip-compilation`.  If you skip both, only the `autolocate!` of the Arduino binary will be performed.
 
 ### Changed
 - Unit tests and examples are now executed alphabetically by filename


### PR DESCRIPTION
This patch allows you to skip compilation and/or unit tests steps

Fixes #93 

I'd like to get #98 in first