### PR TITLE
Don't define ostream& operator() if already defined by Apple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Don't define `ostream& operator<<(nullptr_t)` if already defined by Apple
 
 ### Security
 

--- a/cpp/unittest/OstreamHelpers.h
+++ b/cpp/unittest/OstreamHelpers.h
@@ -2,4 +2,8 @@
 
 #include <ostream>
 
+#if (defined __apple_build_version__) && (__apple_build_version__ >= 12000000)
+// defined in /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/ostream:223:20
+#else
 inline std::ostream& operator << (std::ostream& out, const std::nullptr_t &np) { return out << "nullptr"; }
+#endif


### PR DESCRIPTION
Possible fix for #170. I'm not sure when Xcode started providing this, but it feels recent and this change allows tests to pass for me on my local build. I've tried to make it safe for everyone else.