### PR TITLE
Don't define `ARDUINO=100` if already defined as something else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Don't define `ostream& operator<<(nullptr_t)` if already defined by Apple
+- Don't define `ARDUINO=100` if already defined as something else
 
 ### Security
 

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -334,9 +334,9 @@ module ArduinoCI
         ]
       end
       arg_sets << test_args(aux_libraries, ci_gcc_config)
-      if (arg_sets.flatten(1).index{|s| s.include?("-DARDUINO=")} == nil) 
-        arg_sets << ["-DARDUINO=100"]
-      end
+      index = arg_sets.flatten(1).index { |s| s.include?("-DARDUINO=") }
+      arg_sets << ["-DARDUINO=100"] if index.nil?
+    end
       arg_sets << cpp_files_libraries(aux_libraries).map(&:to_s)
       arg_sets << [test_file.to_s]
       args = arg_sets.flatten(1)

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -324,7 +324,7 @@ module ArduinoCI
       executable = Pathname.new("unittest_#{base}.bin").expand_path
       File.delete(executable) if File.exist?(executable)
       arg_sets = []
-      arg_sets << ["-std=c++0x", "-o", executable.to_s, "-DARDUINO=100"]
+      arg_sets << ["-std=c++0x", "-o", executable.to_s]
       if libasan?(gcc_binary)
         arg_sets << [ # Stuff to help with dynamic memory mishandling
           "-g", "-O1",
@@ -334,6 +334,9 @@ module ArduinoCI
         ]
       end
       arg_sets << test_args(aux_libraries, ci_gcc_config)
+      if (arg_sets.flatten(1).index{|s| s.include?("-DARDUINO=")} == nil) 
+        arg_sets << ["-DARDUINO=100"]
+      end
       arg_sets << cpp_files_libraries(aux_libraries).map(&:to_s)
       arg_sets << [test_file.to_s]
       args = arg_sets.flatten(1)

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -336,7 +336,6 @@ module ArduinoCI
       arg_sets << test_args(aux_libraries, ci_gcc_config)
       index = arg_sets.flatten(1).index { |s| s.include?("-DARDUINO=") }
       arg_sets << ["-DARDUINO=100"] if index.nil?
-    end
       arg_sets << cpp_files_libraries(aux_libraries).map(&:to_s)
       arg_sets << [test_file.to_s]
       args = arg_sets.flatten(1)


### PR DESCRIPTION
Fixes #176