### PR TITLE
Provide digitalPinToPort and related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Add `__AVR__` to defines when compiling
+- Add support for `diditalPinToPort()`, `digitalPinToBitMask()`, and `portOutputRegister()`
 
 ### Changed
 - Move repository from https://github.com/ianfixes/arduino_ci to https://github.com/Arduino-CI/arduino_ci

--- a/SampleProjects/TestSomething/test/outputRegister.cpp
+++ b/SampleProjects/TestSomething/test/outputRegister.cpp
@@ -1,0 +1,23 @@
+#include <ArduinoUnitTests.h>
+#include <Arduino.h>
+
+// https://github.com/arduino-libraries/Ethernet/blob/master/src/utility/w5100.h#L337
+
+unittest(test)
+{
+  uint8_t ss_pin = 12;
+  uint8_t ss_port = digitalPinToPort(ss_pin);
+  assertEqual(12, ss_port);
+  uint8_t *ss_pin_reg = portOutputRegister(ss_port);
+  assertEqual(GODMODE()->pMmapPort(ss_port), ss_pin_reg);
+  uint8_t ss_pin_mask = digitalPinToBitMask(ss_pin);
+  assertEqual(1, ss_pin_mask);
+
+  assertEqual((int) 1, (int) *ss_pin_reg);    // verify initial value
+  *(ss_pin_reg) &= ~ss_pin_mask;              // set SS
+  assertEqual((int) 0, (int) *ss_pin_reg);    // verify value
+  *(ss_pin_reg) |= ss_pin_mask;               // clear SS
+  assertEqual((int) 1, (int) *ss_pin_reg);    // verify value
+}
+
+unittest_main()

--- a/SampleProjects/TestSomething/test/outputRegister.cpp
+++ b/SampleProjects/TestSomething/test/outputRegister.cpp
@@ -1,9 +1,11 @@
 #include <ArduinoUnitTests.h>
 #include <Arduino.h>
 
+// added to fix https://github.com/Arduino-CI/arduino_ci/issues/193
 // https://github.com/arduino-libraries/Ethernet/blob/master/src/utility/w5100.h#L337
 
-unittest(test)
+#if defined(__AVR__)
+unittest(portOutputRegister)
 {
   uint8_t ss_pin = 12;
   uint8_t ss_port = digitalPinToPort(ss_pin);
@@ -19,5 +21,6 @@ unittest(test)
   *(ss_pin_reg) |= ss_pin_mask;               // clear SS
   assertEqual((int) 1, (int) *ss_pin_reg);    // verify value
 }
+#endif
 
 unittest_main()

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -30,14 +30,6 @@ unsigned long micros();
   #define NUM_SERIAL_PORTS 0
 #endif
 
-// These definitions allow the following to compile (see issue #193):
-// https://github.com/arduino-libraries/Ethernet/blob/master/src/utility/w5100.h:341
-// add padding because some boards (__MK20DX128__) offset from the given address
-#define MMAP_PORTS_SIZE (MOCK_PINS_COUNT + 256)
-#define digitalPinToBitMask(pin)  (1)
-#define digitalPinToPort(pin)     (pin)
-#define portOutputRegister(port)  (GODMODE()->pMmapPort(port))
-
 class GodmodeState {
   private:
     struct PortDef {
@@ -51,7 +43,7 @@ class GodmodeState {
       uint8_t mode;
     };
 
-    uint8_t mmapPorts[MMAP_PORTS_SIZE];
+    uint8_t mmapPorts[MOCK_PINS_COUNT];
 
     static GodmodeState* instance;
 
@@ -98,7 +90,7 @@ class GodmodeState {
     }
 
     void resetMmapPorts() {
-      for (int i = 0; i < MMAP_PORTS_SIZE; ++i) {
+      for (int i = 0; i < MOCK_PINS_COUNT; ++i) {
         mmapPorts[i] = 1;
       }
     }
@@ -158,6 +150,17 @@ void detachInterrupt(uint8_t interrupt);
 // TODO: issue #26 to track the commanded state here
 inline void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0) {}
 inline void noTone(uint8_t _pin) {}
+
+// These definitions allow the following to compile (see issue #193):
+// https://github.com/arduino-libraries/Ethernet/blob/master/src/utility/w5100.h:341
+// we allow one byte per port which "wastes" 224 bytes, but makes the code easier
+#if defined(__AVR__)
+  #define digitalPinToBitMask(pin)  (1)
+  #define digitalPinToPort(pin)     (pin)
+  #define portOutputRegister(port)  (GODMODE()->pMmapPort(port))
+#else
+  // we don't (yet) support other boards
+#endif
 
 
 GodmodeState* GODMODE();


### PR DESCRIPTION
I don't understand this very well, but it appears that some boards use memory-mapped I/O to read/write pins. To support that style of code this PR adds an array that can hold pin values. A more elaborate approach would be to connect to the pin logs, but this seems like a decent first step (and allows some files to compile that didn't compile before). Fixes #193.