### PR TITLE
Update test comment to replace deprecated scripts

### DIFF
--- a/SampleProjects/NetworkLib/test/test.cpp
+++ b/SampleProjects/NetworkLib/test/test.cpp
@@ -2,8 +2,7 @@
 cd SampleProjects/NetworkLib
 bundle config --local path vendor/bundle
 bundle install
-bundle exec arduino_ci_remote.rb  --skip-compilation
-# bundle exec arduino_ci_remote.rb  --skip-examples-compilation
+bundle exec arduino_ci.rb  --skip-examples-compilation
 */
 
 #include <Arduino.h>


### PR DESCRIPTION
Use new `arduino_ci.rb` and `--skip-examples-compilation` now that they are available.