### PR TITLE
Add macro for `portInputRegister()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - `arduino_ci_remote.rb` CLI switch `--skip-examples-compilation`
-- Add support for `diditalPinToPort()`, `digitalPinToBitMask()`, and `portOutputRegister()`
+- Add support for `diditalPinToPort()`, `digitalPinToBitMask()`, `portOutputRegister()`, and `portInputRegister()`
 - `CppLibrary.header_files` to find header files
 - `LibraryProperties` to read metadata from Arduino libraries
 - `CppLibrary.library_properties_path`, `CppLibrary.library_properties?`, `CppLibrary.library_properties` to expose library properties of a Cpp library

--- a/SampleProjects/TestSomething/test/outputRegister.cpp
+++ b/SampleProjects/TestSomething/test/outputRegister.cpp
@@ -21,6 +21,23 @@ unittest(portOutputRegister)
   *(ss_pin_reg) |= ss_pin_mask;               // clear SS
   assertEqual((int) 1, (int) *ss_pin_reg);    // verify value
 }
+
+unittest(portInputRegister)
+{
+  uint8_t ss_pin = 12;
+  uint8_t ss_port = digitalPinToPort(ss_pin);
+  assertEqual(12, ss_port);
+  uint8_t *ss_pin_reg = portInputRegister(ss_port);
+  assertEqual(GODMODE()->pMmapPort(ss_port), ss_pin_reg);
+  uint8_t ss_pin_mask = digitalPinToBitMask(ss_pin);
+  assertEqual(1, ss_pin_mask);
+
+  assertEqual((int) 1, (int) *ss_pin_reg);    // verify initial value
+  *(ss_pin_reg) &= ~ss_pin_mask;              // set SS
+  assertEqual((int) 0, (int) *ss_pin_reg);    // verify value
+  *(ss_pin_reg) |= ss_pin_mask;               // clear SS
+  assertEqual((int) 1, (int) *ss_pin_reg);    // verify value
+}
 #endif
 
 unittest_main()

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -182,6 +182,7 @@ inline void noTone(uint8_t _pin) {}
 #if defined(__AVR__)
   #define digitalPinToBitMask(pin)  (1)
   #define digitalPinToPort(pin)     (pin)
+  #define portInputRegister(port)   (GODMODE()->pMmapPort(port))
   #define portOutputRegister(port)  (GODMODE()->pMmapPort(port))
 #else
   // we don't (yet) support other boards


### PR DESCRIPTION
Fix #210 (follow-up from #193).