### PR TITLE
Fix typo in `aux_libraries` name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Don't define `ostream& operator<<(nullptr_t)` if already defined by Apple
 - `CppLibrary.in_tests_dir?` no longer produces an error if there is no tests directory
 - The definition of the `_SFR_IO8` macro no longer produces errors about rvalues
+- Typo in `cpp_library.rb`, misspelling of `aux_libraries`
 
 ### Deprecated
 - `arduino_ci_remote.rb` CLI switch `--skip-compilation`

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -410,7 +410,7 @@ module ArduinoCI
 
       # combine library.properties defs (if existing) with config file.
       # TODO: as much as I'd like to rely only on the properties file(s), I think that would prevent testing 1.0-spec libs
-      full_aux_libraries = arduino_library_dependencies.nil? ? aux_libraries : aux_libaries + arduino_library_dependencies
+      full_aux_libraries = arduino_library_dependencies.nil? ? aux_libraries : aux_libraries + arduino_library_dependencies
       arg_sets << test_args(full_aux_libraries, ci_gcc_config)
       arg_sets << cpp_files_libraries(full_aux_libraries).map(&:to_s)
       arg_sets << [test_file.to_s]


### PR DESCRIPTION
See https://github.com/jgfoster/Adafruit_MAX31865/runs/1401861281?check_suite_focus=true for a failure.