### PR TITLE
Actions macos

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,58 @@
+# This is the name of the workflow, visible on GitHub UI
+name: macos
+
+# Run on a Push or a Pull Request
+on: [push, pull_request]
+
+jobs:
+  rubocop: 
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: 2.6
+
+      # Install and run Arduino CI tests for rubocop
+      - name: Build and Execute
+        run: |
+          g++ -v
+          bundle install
+          bundle exec rubocop --version
+          bundle exec rubocop -D .
+          bundle exec rspec --backtrace
+
+  TestSomething: 
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: 2.6
+
+      # Install and run Arduino CI tests for TestSomething
+      - name: Build and Execute
+        run: |
+          g++ -v
+          bundle install
+          cd SampleProjects/TestSomething
+          bundle install
+          bundle exec arduino_ci.rb
+
+  NetworkLib: 
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with: 
+          ruby-version: 2.6
+
+      # Install and run Arduino CI tests for NetworkLib
+      - name: Build and Execute
+        run: |
+          g++ -v
+          bundle install
+          cd SampleProjects/NetworkLib
+          ./scripts/install.sh
+          bundle install
+          bundle exec arduino_ci.rb


### PR DESCRIPTION
Highlights how the latest macOS currently does NOT run Arduino CI. Related to issues #155 and #185.