### PR TITLE
Add git attributes to force only lf line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf


### PR DESCRIPTION
In setting up GitHub Actions, I noticed that `bundle exec rubocop -D .` was throwing 25 offense for something like this:

```
Gemfile:1:1: C: Layout/EndOfLine: Carriage return character detected.
source "https://rubygems.org" ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I added a `.gitattributes` file to force **lf** line endings to match the rubocop settings in `.rubocop.yml`