### PR TITLE
Support delay() callback/handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Ability to use event handlers on a delay
 
 ### Changed
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -709,3 +709,21 @@ unittest(wire_basics) {
   assertEqual(0, mosi->size());
 }
 ```
+
+### Delay
+
+When running on the real Arduino, the `delay()` function will actually pause.
+When running on the mock Arduino, the `delay()` function increments the clock
+and then returns immediately. While this generally the right thing to do,
+this presents a couple issues. First, if we want to look at the state during
+the delay, this is difficult since the state could change after the delay
+(e.g., show a message on the LCD for one second, then clear it). Second, if
+we are using the mock Arduino library to emulate the application in a GUI,
+we want to have a real delay. To solve this, we will allow code (such as tests
+and the GUI) to register to be notified of delays. Then we can take whatever
+actionion is appropriate.
+
+To be notified of a delay, define a void function that accepts a single
+`unsigned long int` as a parameter and register the function using `addDelayHandler()`.
+You can remove the callback with `removeDelayHandler()`. For an example of the usage,
+see `millis_micros_and_delay` in `SampleProjects/TestSomething/test/godmode.cpp`.

--- a/SampleProjects/TestSomething/test/godmode.cpp
+++ b/SampleProjects/TestSomething/test/godmode.cpp
@@ -10,7 +10,14 @@ unittest_setup() {
   state->reset();
 }
 
+unsigned long myDelay = 0;
+
+void delayHandler(unsigned long micros) {
+  myDelay = micros;
+}
+
 unittest(millis_micros_and_delay) {
+  assertEqual(0, myDelay);
   assertEqual(0, millis());
   assertEqual(0, micros());
   delay(3);
@@ -19,6 +26,18 @@ unittest(millis_micros_and_delay) {
   delayMicroseconds(11000);
   assertEqual(14, millis());
   assertEqual(14000, micros());
+  assertEqual(0, myDelay);
+
+  addDelayHandler(delayHandler);
+  delay(2);
+  assertEqual(2000, myDelay);
+  myDelay = 9;
+  delayMicroseconds(25);
+  assertEqual(25, myDelay);
+  removeDelayHandler(delayHandler);
+  myDelay = 0;
+  delay(4);
+  assertEqual(0, myDelay);
 }
 
 unittest(random) {

--- a/cpp/arduino/Godmode.cpp
+++ b/cpp/arduino/Godmode.cpp
@@ -2,6 +2,7 @@
 #include "HardwareSerial.h"
 #include "SPI.h"
 #include "Wire.h"
+#include <list>
 
 GodmodeState* GODMODE() {
   return GodmodeState::getInstance();
@@ -32,11 +33,27 @@ unsigned long micros() {
 }
 
 void delay(unsigned long millis) {
-  GODMODE()->micros += millis * 1000;
+  delayMicroseconds(millis * 1000);
 }
 
+std::list<DelayHandler> delayHandlers;
+
 void delayMicroseconds(unsigned long micros) {
+  for (auto each : delayHandlers) {
+    each(micros);
+  }
   GODMODE()->micros += micros;
+}
+
+void addDelayHandler(DelayHandler pFunction) {
+  delayHandlers.push_back(pFunction);
+}
+
+void removeDelayHandler(DelayHandler pFunction) {
+  std::list<DelayHandler>::iterator iter = std::find(delayHandlers.begin(), delayHandlers.end(), pFunction);
+  if (iter != delayHandlers.end()) {
+    delayHandlers.erase(iter);
+  }
 }
 
 void randomSeed(unsigned long seed)

--- a/cpp/arduino/Godmode.h
+++ b/cpp/arduino/Godmode.h
@@ -13,10 +13,13 @@ long random(long vmin, long vmax);
 
 
 // Time
+typedef void (*DelayHandler)(unsigned long micros);
 void delay(unsigned long millis);
 void delayMicroseconds(unsigned long micros);
 unsigned long millis();
 unsigned long micros();
+void addDelayHandler(DelayHandler pFunction);
+void removeDelayHandler(DelayHandler pFunction);
 
 #define MOCK_PINS_COUNT 256
 


### PR DESCRIPTION
When running on the real Arduino, the `delay()` function will actually pause. When running on the mock Arduino, the `delay()` function increments the clock and then returns immediately. While this is generally the right thing to do, this presents a couple issues. First, if we want to look at the state during the delay, this is difficult since the state could change after the delay (e.g., show a message on the LCD for one second, then clear it). Second, if we are using the mock Arduino library to emulate the application in a GUI, we want to have a real delay. To solve this, we will allow code (such as tests and the GUI) to register to be notified of delays. Then we can take whatever actionion is appropriate.

To be notified of a delay, define a void function that accepts a single `unsigned long int` as a parameter and register the function using `addDelayHandler()`. You can remove the callback with `removeDelayHandler()`. For an example of the usage, see `millis_micros_and_delay` in `SampleProjects/TestSomething/test/godmode.cpp`.
