### PR TITLE
Build a shared library for use with each test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ vendor
 # C++ stuff
 *.bin
 *.bin.dSYM
+*.so
+*.so.dSYM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 ### Changed
+- We now compile a shared library to be used for each test
 
 ### Deprecated
 

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -470,16 +470,15 @@ module ArduinoCI
       ci_gcc_config[:flags]
     end
 
-    # All GCC command line args for building any unit test
+    # All non-CPP GCC command line args for building any unit test.
+    # We leave out the CPP files so they can be included or not
+    # depending on whether we are building a shared library.
     # @param aux_libraries [Array<Pathname>] The external Arduino libraries required by this project
     # @param ci_gcc_config [Hash] The GCC config object
     # @return [Array<String>] GCC command-line flags
     def test_args(aux_libraries, ci_gcc_config)
       # TODO: something with libraries?
       ret = include_args(aux_libraries)
-      # ret += cpp_files_arduino.map(&:to_s)
-      # ret += cpp_files_unittest.map(&:to_s)
-      # ret += cpp_files.map(&:to_s)
       unless ci_gcc_config.nil?
         cgc = ci_gcc_config
         ret = feature_args(cgc) + warning_args(cgc) + define_args(cgc) + flag_args(cgc) + ret
@@ -520,7 +519,6 @@ module ArduinoCI
         ]
       end
 
-      # puts "#{Time.now.to_s} arg_sets" # = #{arg_sets.to_s}"
       # combine library.properties defs (if existing) with config file.
       # TODO: as much as I'd like to rely only on the properties file(s), I think that would prevent testing 1.0-spec libs
       arg_sets << @@test_args # used cached value since building full set of include directories can take time


### PR DESCRIPTION
Instead of recompiling all the source files for each test, we now build a single shared library with everything except the test and then compile the test and link to the shared library. When I test SampleProjects/TestSomething the time reduces from 2:25 to 0:48. On our TankControllerLib, tests typically take over 30 minutes on my machine and this change reduces the time to just over two minutes, so a massive win!

I realize that I'm getting pretty deep into the internals, and I've not tested this on Linux or Windows so we'll see if the GitHub Action catches anything!

Fix #227. 