### PR TITLE
Stream::readStreamUntil() should not return delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Topmost installtion instructions now suggest `gem install arduino_ci` instead of using a `Gemfile`.  Reasons for using a `Gemfile` are listed and discussed separately further down the README.
+- Stream::readStreamUntil() no longer returns delimiter
 
 ### Removed
 - scanning of `library.properties`; this can and should now be performed by the standalone [`arduino-lint` tool](https://arduino.github.io/arduino-lint).

--- a/SampleProjects/TestSomething/test/stream.cpp
+++ b/SampleProjects/TestSomething/test/stream.cpp
@@ -69,4 +69,16 @@ unittest(stream_parse)
 
 }
 
+unittest(readStringUntil) {
+  String data = "";
+  unsigned long micros = 100;
+  data = "abc:def";
+
+  Stream s;
+  s.mGodmodeDataIn = &data;
+  s.mGodmodeMicrosDelay = &micros;
+  // result should not include delimiter
+  assertEqual("abc", s.readStringUntil(':'));
+  assertEqual("def", s.readStringUntil(':'));
+}
 unittest_main()

--- a/cpp/arduino/Stream.h
+++ b/cpp/arduino/Stream.h
@@ -186,7 +186,7 @@ class Stream : public Print
         ret = String(*mGodmodeDataIn);
         mGodmodeDataIn->clear();
       } else {
-        ret = mGodmodeDataIn->substring(0, idxTrm + 1);
+        ret = mGodmodeDataIn->substring(0, idxTrm);
         fastforward(idxTrm + 1);
       }
       return ret;


### PR DESCRIPTION
The delimiter should not be included in the returned String.