### PR TITLE
Allow `yield()` to be defined in library code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Change 266 files from CRLF to LF.
+- Replace `#define yield() _NOP()` with `inline void yield() { _NOP(); }` so that other code can define a `yield()` function.
 
 ### Deprecated
 

--- a/cpp/arduino/Arduino.h
+++ b/cpp/arduino/Arduino.h
@@ -36,11 +36,11 @@ typedef uint8_t byte;
 #define highByte(w) ((uint8_t) ((w) >> 8))
 #define lowByte(w) ((uint8_t) ((w) & 0xff))
 
-// might as well use that NO-op macro for these, while unit testing
-// you need interrupts? interrupt yourself
-#define yield() _NOP()
-#define interrupts() _NOP()
-#define noInterrupts() _NOP()
+// using #define for these makes it impossible for other code to use as function
+// names!
+inline void yield() { _NOP(); }
+inline void interrupts() { _NOP(); }
+inline void noInterrupts() { _NOP(); }
 
 // TODO: correctly establish this per-board!
 #define F_CPU 1000000UL


### PR DESCRIPTION
Replace `#define yield() _NOP()` with `inline void yield() { _NOP(); }` so that other code can define a `yield()` function.