### PR TITLE
Allow compiling with Watchdog Timer calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Better indications of the build phases in the test runner `arduino_ci.rb`
 - Better indications of which example sketch is being compiled as part of testing
+- Allow use of watchdog timer in application code (though it doesn't do anything)
 
 ### Changed
 - Topmost installtion instructions now suggest `gem install arduino_ci` instead of using a `Gemfile`.  Reasons for using a `Gemfile` are listed and discussed separately further down the README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Allow use of watchdog timer in application code (though it doesn't do anything)
 
 ### Changed
 - Change 266 files from CRLF to LF.
@@ -24,7 +25,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Better indications of the build phases in the test runner `arduino_ci.rb`
 - Better indications of which example sketch is being compiled as part of testing
-- Allow use of watchdog timer in application code (though it doesn't do anything)
 
 ### Changed
 - Topmost installtion instructions now suggest `gem install arduino_ci` instead of using a `Gemfile`.  Reasons for using a `Gemfile` are listed and discussed separately further down the README.

--- a/SampleProjects/TestSomething/test/wdt.cpp
+++ b/SampleProjects/TestSomething/test/wdt.cpp
@@ -1,0 +1,12 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+#include <avr/wdt.h>
+
+unittest(wdt) {
+  wdt_disable();
+  wdt_enable(WDTO_8S);
+  wdt_reset();
+  assertTrue(true);
+}
+
+unittest_main()

--- a/cpp/arduino/avr/wdt.h
+++ b/cpp/arduino/avr/wdt.h
@@ -1,0 +1,16 @@
+// Stub for testing that doesn't do anything (but at least compiles!)
+
+#define wdt_disable() (void)0
+#define wdt_enable(timeout) (void)0
+#define wdt_reset() (void)0
+
+#define WDTO_15MS 0
+#define WDTO_30MS 1
+#define WDTO_60MS 2
+#define WDTO_120MS 3
+#define WDTO_250MS 4
+#define WDTO_500MS 5
+#define WDTO_1S 6
+#define WDTO_2S 7
+#define WDTO_4S 8
+#define WDTO_8S 9


### PR DESCRIPTION
Add `avr/wdt.h` and simple test that ensures the header can be found and the functions can be called.