### PR TITLE
Fix open-uri call for downloading release files

### DIFF
--- a/lib/arduino_ci/arduino_downloader.rb
+++ b/lib/arduino_ci/arduino_downloader.rb
@@ -108,7 +108,7 @@ module ArduinoCI
         dots = needed_dots
       end
 
-      open(package_url, ssl_verify_mode: 0, progress_proc: dot_printer) do |url|
+      URI.open(package_url, ssl_verify_mode: 0, progress_proc: dot_printer) do |url|
         File.open(package_file, 'wb') { |file| file.write(url.read) }
       end
     rescue Net::OpenTimeout, Net::ReadTimeout, OpenURI::HTTPError, URI::InvalidURIError => e


### PR DESCRIPTION
This fixes the [issue](https://github.com/Arduino-CI/arduino_ci/issues/291) where attempting to download releases from <https://github.com/arduino/arduino-cli/releases/download/> fails.
