### PR TITLE
Avoid error when no examples directory entries exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Apply "rule of three" to Client copy constructor and copy assignment operator
 - Run Windows tests on Windows not Ubuntu
 - Properly report error in building shared library
+- A missing `examples` directory no longer causes a crash in `cpp_library.rb`
 
 ### Security
 

--- a/exe/arduino_ci.rb
+++ b/exe/arduino_ci.rb
@@ -63,7 +63,6 @@ class Parser
         puts " - #{VAR_USE_SUBDIR} - if set, the script will install the library from this subdirectory of the cwd"
         puts " - #{VAR_EXPECT_EXAMPLES} - if set, testing will fail if no example sketches are present"
         puts " - #{VAR_EXPECT_UNITTESTS} - if set, testing will fail if no unit tests are present"
-        puts " - #{VAR_SKIP_LIBPROPS} - if set, testing will skip [experimental] library.properties validation"
         exit
       end
     end

--- a/exe/arduino_ci.rb
+++ b/exe/arduino_ci.rb
@@ -91,7 +91,7 @@ def terminate(final = nil)
 end
 
 # make a nice status line for an action and react to the action
-# TODO / note to self: inform_multline is tougher to write
+# TODO / note to self: inform_multiline is tougher to write
 #   without altering the signature because it only leaves space
 #   for the checkmark _after_ the multiline, it doesn't know how
 #   to make that conditionally the body
@@ -112,7 +112,7 @@ def perform_action(message, multiline, mark_fn, on_fail_msg, tally_on_fail, abor
   $stdout.flush
   result = yield
   mark = mark_fn.nil? ? "" : mark_fn.call(result)
-  # if multline, put checkmark at full width
+  # if multiline, put checkmark at full width
   print endline if multiline
   puts mark.to_s.rjust(WIDTH - line.length, " ")
   unless result

--- a/lib/arduino_ci/cpp_library.rb
+++ b/lib/arduino_ci/cpp_library.rb
@@ -135,7 +135,10 @@ module ArduinoCI
     # @param installed_library_path [String] The library to query
     # @return [Array<String>] Example sketch files
     def example_sketches
-      reported_dirs = info["library"]["examples"].map(&Pathname::method(:new))
+      examples = info["library"]["examples"]
+      return [] if examples.nil?
+
+      reported_dirs = examples.map(&Pathname::method(:new))
       reported_dirs.map { |e| e + e.basename.sub_ext(".ino") }.select(&:exist?).sort_by(&:to_s)
     end
 


### PR DESCRIPTION
Here is an extract and rebase of some local changes I had in my repo that fixes #324. The fix commit is a cherry-pick from the `2021-02-15_rescue` branch of ianfixes's fork.

`bundle exec arduino_ci.rb` still crashes if the `examples` directory does not exists at all.
