### PR TITLE
Make LED_BUILTIN definition available for Arduino Due, Zero and Circuit Playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix missing `LED_BUILTIN` definition for Arduino Due.
+
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix missing `LED_BUILTIN` definition for Arduino Due.
+- Fix missing `LED_BUILTIN` definition for Arduino Due, Zero and Circuit Playground.
 
 ### Security
 

--- a/cpp/arduino/ArduinoDefines.h
+++ b/cpp/arduino/ArduinoDefines.h
@@ -89,7 +89,7 @@
 #define TIMER5B 17
 #define TIMER5C 18
 
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__SAM3X8E__)
   #define LED_BUILTIN 13
 #endif
 

--- a/cpp/arduino/ArduinoDefines.h
+++ b/cpp/arduino/ArduinoDefines.h
@@ -89,7 +89,7 @@
 #define TIMER5B 17
 #define TIMER5C 18
 
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__SAM3X8E__)
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(__SAM3X8E__) || defined(__SAMD21G18A__)
   #define LED_BUILTIN 13
 #endif
 


### PR DESCRIPTION
Updates to CHANGELOG.md will trigger conflicts for this branch (`led_builtin.m`, rebased on top of `master`) when #338 is completed (or if this is done first, then #338 will get conflicts).

There is an alternative branch `led_builtin` applied in series with other branches that does not have those conflicts when #338 is completed. Let me know if you rather want that one merged (later).