### PR TITLE
Fix issue #352 - backend used before assigned when loading dependencies

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -4,6 +4,21 @@ name: linux
 on: [push, pull_request]
 
 jobs:
+  "BusIO_with_dependencies":
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Check usage - Test BusIO from scratch
+        run: |
+          g++ -v
+          cd SampleProjects/BusIO
+          bundle install
+          bundle exec ensure_arduino_installation.rb
+          bundle exec arduino_ci.rb
+
   "rubocop":
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+- Fixes #352, in which the Arduino backend was being referenced in the CI runner before being explicitly assigned; this affected all tests of modules that used `library.properties` to specify runtime Arduino module dependencies.
 
 ### Security
 

--- a/SampleProjects/BusIO/.arduino-ci.yml
+++ b/SampleProjects/BusIO/.arduino-ci.yml
@@ -2,11 +2,10 @@ unittest:
   platforms:
     - mega2560
   libraries:
-    - "Adafruit BusIO"
-    # - "Adafruit_BusIO"    <= This works if you have the library pre-installed
+    - "Adafruit_BusIO"
 
 compile:
   platforms:
     - mega2560
   libraries:
-    - "Adafruit BusIO"
+    - "Adafruit_BusIO"

--- a/SampleProjects/BusIO/README.md
+++ b/SampleProjects/BusIO/README.md
@@ -1,4 +1,8 @@
 # BusIO
 
 This is an example of a library that depends on Adafruit BusIO.
-It is provided to help reproduce #192.
+It is provided to help reproduce #192 and #352.
+
+This example specifies a dependency in `library.properties`, which
+exercises the `arduino_ci.rb` CI runner in a way that the other
+SampleProjects currently do not.

--- a/SampleProjects/BusIO/library.properties
+++ b/SampleProjects/BusIO/library.properties
@@ -8,3 +8,4 @@ category=Other
 url=https://github.com/Arduino-CI/arduino_ci/SampleProjects/BusIO
 architectures=avr,esp8266
 includes=BusIO.h
+depends=Adafruit BusIO

--- a/exe/arduino_ci.rb
+++ b/exe/arduino_ci.rb
@@ -351,11 +351,6 @@ def perform_bootstrap
     end
   end
 
-  install_arduino_library_dependencies(
-    cpp_library.arduino_library_dependencies,
-    "<#{ArduinoCI::CppLibrary::LIBRARY_PROPERTIES_FILE}>"
-  )
-
   # return all objects needed by other steps
   {
     backend: backend,
@@ -604,6 +599,12 @@ end
 
 strap = perform_bootstrap
 @backend = strap[:backend]
+
+install_arduino_library_dependencies(
+  strap[:cpp_library].arduino_library_dependencies,
+  "<#{ArduinoCI::CppLibrary::LIBRARY_PROPERTIES_FILE}>"
+)
+
 perform_unit_tests(strap[:cpp_library], strap[:config])
 perform_example_compilation_tests(strap[:cpp_library], strap[:config])
 


### PR DESCRIPTION
## Highlights from `CHANGELOG.md`

* See CHANGELOG.md for more

## Issues Fixed

* Fixes #352 